### PR TITLE
Fix: ADMIN | JS - ACCOMMODATION - Selecting 'All' needs a page refresh

### DIFF
--- a/spec/accommodation/list/HappyPathSpec.js
+++ b/spec/accommodation/list/HappyPathSpec.js
@@ -157,8 +157,14 @@ describe('Accommodation Listing', () => {
     it('- should show user it has loaded', () => {
       expect(browserLoadedStub.calledAfter(ajaxGetStub)).toBeTruthy()
     })
+
+    it('- should reload all accommodation when reset to \'All\'', () => {
+      sut.selectedCityFilter(null);
+      expect(sut.entries().length).toEqual(accomData.items.length);
+    })
   })
 })
+
 
 const accomData = {
   'links': {

--- a/src/js/models/accommodation/list.js
+++ b/src/js/models/accommodation/list.js
@@ -45,7 +45,12 @@ function Lister () {
   }
 
   self.selectedCityFilter.subscribe((newCityToFilterOn) => {
-    loadNextUrl = `${endpoints.temporaryAccommodation}?cityId=${newCityToFilterOn}`
+    if(newCityToFilterOn) {
+      loadNextUrl = `${endpoints.temporaryAccommodation}?cityId=${newCityToFilterOn}`
+    } else {
+      loadNextUrl = endpoints.temporaryAccommodation
+    }
+
     self.entries([])
     self.loadNext()
   })


### PR DESCRIPTION
The 'All' option submitted an undefined city ID being submitted to the temporary accommodation endpoint, which resulted in an empty list being retrieved. Adding an if statement to reset the URL to default if no city ID has been selected resolves this issue.