### PR TITLE
1690 - make menu items more responsive above medium breakpoint

### DIFF
--- a/src/partials/header-nav.hbs
+++ b/src/partials/header-nav.hbs
@@ -14,7 +14,4 @@
     <li class="nav__item nav__item--swep" data-claims="superadmin,cityadminfor:manchester"><a href="/swep">SWEP</a></li>
     <li class="nav__item nav__item--accommodation" data-claims="superadmin,tempaccomadmin,orgadmin,cityadmin"><a href="/accommodation">Accommodation</a></li>
   </ul>
-  <ul class="nav__list header-nav__list">
-    <li class="nav__item"><a href="/logout.html">Logout</a></li>
-  </ul>
 </nav>

--- a/src/scss/modules/_variables.scss
+++ b/src/scss/modules/_variables.scss
@@ -88,10 +88,8 @@ $font-headline-weight: 500;
 // Header & Nav
 $header-top: 117px;
 
-$header-height: 44px;
 $header-margin: 44px;
 
-$header-subnav-height: 85px;
 $header-subnav-margin: 85px;
 
 $nav-width: 220px;

--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -31,7 +31,6 @@
     position: fixed;
     top: 0;
     right: 0;
-    height: 100%;
     width: $nav-width;
     z-index: 30;
     overflow-y: scroll;
@@ -47,16 +46,11 @@
       position: absolute;
       top: $header-top;
       width: 100%;
-      height: $header-subnav-height;
       transition: none;
       transform: none;
       box-shadow: 0px 2px 5px 0px rgba(50, 50, 50, 0.7);
       border-top: 2px solid $brand-i;
       overflow-y: hidden;
-
-      .section--nosubnav & {
-        height: $header-height;
-      }
     }
 
     &.is-active {


### PR DESCRIPTION
causes menu to break over multiple lines when going above the medium breakpoint
and remove the superfluous hidden logout link